### PR TITLE
[2.0.x-bugfix] Ender 3 correct bed size

### DIFF
--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -939,8 +939,8 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 220
-#define Y_BED_SIZE 220
+#define X_BED_SIZE 235
+#define Y_BED_SIZE 235
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0


### PR DESCRIPTION
### Description

Ender 3 bed size was set to 220 but is 235 in reality. Confirmed in manufacturer's original firmware configuration [1]

[1] https://github.com/Creality3DPrinting/Ender-3

### Benefits

Increase printable area

### Related Issues

